### PR TITLE
Iteration 1 - Make it work without modifying the unit tests

### DIFF
--- a/ChessProject-Java/src/main/java/com/solarwindsmsp/chess/ChessBoard.java
+++ b/ChessProject-Java/src/main/java/com/solarwindsmsp/chess/ChessBoard.java
@@ -2,21 +2,40 @@ package com.solarwindsmsp.chess;
 
 public class ChessBoard {
 
-    public static int MAX_BOARD_WIDTH = 7;
-    public static int MAX_BOARD_HEIGHT = 7;
+    public final static int MAX_BOARD_WIDTH = 7;
+    public final static int MAX_BOARD_HEIGHT = 7;
 
-    private Pawn[][] pieces;
+    private IPiece[][] pieces;
 
     public ChessBoard() {
         pieces = new Pawn[MAX_BOARD_WIDTH][MAX_BOARD_HEIGHT];
 
     }
 
-    public void Add(Pawn pawn, int xCoordinate, int yCoordinate, PieceColor pieceColor) {
-        throw new UnsupportedOperationException("Need to implement ChessBoard.add()");
+    public void Add(IPiece newPieceToAdd, int xCoordinate, int yCoordinate, PieceColor pieceColor) {
+        if(IsLegalBoardPosition(xCoordinate, yCoordinate)) {
+            pieces[xCoordinate][yCoordinate] = newPieceToAdd;
+            newPieceToAdd.setXCoordinate(xCoordinate);
+            newPieceToAdd.setYCoordinate(yCoordinate);
+            newPieceToAdd.setChessBoard(this);
+        }
+        else {
+            newPieceToAdd.setXCoordinate(-1);
+            newPieceToAdd.setYCoordinate(-1);
+        }
+    }
+
+    public void RemovePieceAt(int xCoordinate, int yCoordinate) {
+        if(IsLegalBoardPosition(xCoordinate, yCoordinate)) {
+            pieces[xCoordinate][yCoordinate] = null;
+        }
     }
 
     public boolean IsLegalBoardPosition(int xCoordinate, int yCoordinate) {
-        throw new UnsupportedOperationException("Need to implement ChessBoard.IsLegalBoardPosition()");
+        return xCoordinate >=0 &&
+                xCoordinate < MAX_BOARD_WIDTH &&
+                yCoordinate >= 0 &&
+                yCoordinate < MAX_BOARD_HEIGHT;
     }
+
 }

--- a/ChessProject-Java/src/main/java/com/solarwindsmsp/chess/IPiece.java
+++ b/ChessProject-Java/src/main/java/com/solarwindsmsp/chess/IPiece.java
@@ -1,0 +1,18 @@
+package com.solarwindsmsp.chess;
+
+public interface IPiece {
+
+    ChessBoard getChesssBoard();
+    void setChessBoard(ChessBoard chessBoard);
+
+    int getXCoordinate();
+    void setXCoordinate(int value);
+
+    int getYCoordinate();
+    void setYCoordinate(int value);
+
+    void Move(MovementType movementType, int newX, int newY);
+
+    PieceColor getPieceColor();
+
+}

--- a/ChessProject-Java/src/main/java/com/solarwindsmsp/chess/Pawn.java
+++ b/ChessProject-Java/src/main/java/com/solarwindsmsp/chess/Pawn.java
@@ -1,50 +1,9 @@
 package com.solarwindsmsp.chess;
 
-public class Pawn {
-
-    private ChessBoard chessBoard;
-    private int xCoordinate;
-    private int yCoordinate;
-    private PieceColor pieceColor;
+public class Pawn extends Piece implements IPiece {
 
     public Pawn(PieceColor pieceColor) {
-        this.pieceColor = pieceColor;
-    }
-
-    public ChessBoard getChesssBoard() {
-        return chessBoard;
-    }
-
-    public void setChessBoard(ChessBoard chessBoard) {
-        this.chessBoard = chessBoard;
-    }
-
-    public int getXCoordinate() {
-        return xCoordinate;
-    }
-
-    public void setXCoordinate(int value) {
-        this.xCoordinate = value;
-    }
-
-    public int getYCoordinate() {
-        return yCoordinate;
-    }
-
-    public void setYCoordinate(int value) {
-        this.yCoordinate = value;
-    }
-
-    public PieceColor getPieceColor() {
-        return this.pieceColor;
-    }
-
-    private void setPieceColor(PieceColor value) {
-        pieceColor = value;
-    }
-
-    public void Move(MovementType movementType, int newX, int newY) {
-        throw new UnsupportedOperationException("Need to implement Pawn.Move()") ;
+        super(pieceColor);
     }
 
     @Override
@@ -54,6 +13,44 @@ public class Pawn {
 
     protected String CurrentPositionAsString() {
         String eol = System.lineSeparator();
-        return String.format("Current X: {1}{0}Current Y: {2}{0}Piece Color: {3}", eol, xCoordinate, yCoordinate, pieceColor);
+        return String.format("%sCurrent X: %dCurrent Y: %dPiece Color: %s", eol, this.getXCoordinate(), this.getYCoordinate(), this.getPieceColor());
     }
+
+    public boolean allowMoveTo(int newX, int newY) {
+        if(this.getPieceColor() == PieceColor.BLACK) {
+            return checkBlackMove(newX, newY);
+        } else {
+            return checkWhiteMove(newX, newY);
+        }
+
+    }
+
+    private boolean checkWhiteMove(int newX, int newY) {
+        final int yDistanceMoved = newY - getYCoordinate();
+
+        final boolean newyOK = getYCoordinate() == 1 ?
+                yDistanceMoved == 1 || yDistanceMoved == 2 :
+                yDistanceMoved == 1;
+        final boolean newxOK = getXCoordinate() == newX;
+
+        return newxOK && newyOK;
+    }
+
+    private boolean checkBlackMove(int newX, int newY) {
+
+        final int yDistanceMoved = getYCoordinate() - newY;
+        final boolean newyOK = getYCoordinate() == ChessBoard.MAX_BOARD_HEIGHT - 1 ?
+                yDistanceMoved == 1 || yDistanceMoved == 2 :
+                yDistanceMoved == 1;
+        final boolean newxOK = getXCoordinate() == newX;
+
+        return newxOK && newyOK;
+    }
+
+
+    public boolean allowCaptureAt(int newX, int newY) {
+        throw new UnsupportedOperationException("Need to implement Pawn.allowCaptureAt");
+    }
+
+
 }

--- a/ChessProject-Java/src/main/java/com/solarwindsmsp/chess/Piece.java
+++ b/ChessProject-Java/src/main/java/com/solarwindsmsp/chess/Piece.java
@@ -1,0 +1,75 @@
+package com.solarwindsmsp.chess;
+
+public abstract class Piece implements IPiece {
+
+    private ChessBoard chessBoard;
+    private int xCoordinate;
+    private int yCoordinate;
+    private PieceColor pieceColor;
+
+    public Piece(PieceColor pieceColor) {
+        this.pieceColor = pieceColor;
+        this.xCoordinate = -1;
+        this.yCoordinate = -1;
+    }
+
+    public ChessBoard getChesssBoard() {
+        return chessBoard;
+    }
+
+    public void setChessBoard(ChessBoard chessBoard) {
+        this.chessBoard = chessBoard;
+    }
+
+    public int getXCoordinate() {
+        return xCoordinate;
+    }
+
+    public void setXCoordinate(int value) {
+        this.xCoordinate = value;
+    }
+
+    public int getYCoordinate() {
+        return yCoordinate;
+    }
+
+    public void setYCoordinate(int value) {
+        this.yCoordinate = value;
+    }
+
+    public PieceColor getPieceColor() {
+        return this.pieceColor;
+    }
+
+    public void Move(MovementType movementType, int newX, int newY) {
+
+        if (this.chessBoard != null && chessBoard.IsLegalBoardPosition(newX, newY)) {
+            switch (movementType) {
+                case MOVE:
+                    if (allowMoveTo(newX, newY)) {
+                        executeMoveForPiece(newX, newY);
+                    }
+                    break;
+                case CAPTURE:
+                    if (allowCaptureAt(newX, newY)) {
+                        executeMoveForPiece(newX, newY);
+                    }
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Illegal or unspecified movement type");
+            }
+        }
+
+    }
+
+    public abstract boolean allowMoveTo(int newX, int newY);
+
+    public abstract boolean allowCaptureAt(int newX, int newY);
+
+    private void executeMoveForPiece(int newX, int newY) {
+        getChesssBoard().RemovePieceAt(getXCoordinate(), getYCoordinate());
+        getChesssBoard().Add(this, newX, newY, this.pieceColor);
+    }
+
+
+}

--- a/ChessProject-Java/src/test/java/com/solarwindsmsp/chess/ChessBoardTest.java
+++ b/ChessProject-Java/src/test/java/com/solarwindsmsp/chess/ChessBoardTest.java
@@ -41,7 +41,7 @@ public class ChessBoardTest extends TestCase {
     @Test
     public void testIsLegalBoardPosition_False_X_equals_11_Y_equals_5() {
         boolean isValidPosition = testSubject.IsLegalBoardPosition(11, 5);
-        assertTrue(isValidPosition);
+        assertFalse(isValidPosition);
     }
 
     @Test

--- a/ChessProject-Java/src/test/java/com/solarwindsmsp/chess/PawnAdditionalMethodsTest.java
+++ b/ChessProject-Java/src/test/java/com/solarwindsmsp/chess/PawnAdditionalMethodsTest.java
@@ -1,0 +1,39 @@
+package com.solarwindsmsp.chess;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PawnAdditionalMethodsTest {
+
+    private ChessBoard chessBoard;
+    private Pawn testSubject;
+
+    @Before
+    public void setUp() {
+        this.chessBoard = new ChessBoard();
+        this.testSubject = new Pawn(PieceColor.BLACK);
+    }
+
+    @Test
+    public void testToString_outOffTheBoard() {
+        String toString = testSubject.toString();
+        assertEquals("\nCurrent X: -1Current Y: -1Piece Color: BLACK", toString);
+
+    }
+
+    @Test
+    public void testToString_onTheBoard() {
+        chessBoard.Add(testSubject, 1, 1, PieceColor.BLACK);
+        String toString = testSubject.toString();
+        assertEquals("\nCurrent X: 1Current Y: 1Piece Color: BLACK", toString);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void test_capture() {
+        chessBoard.Add(testSubject, 1, 1, PieceColor.BLACK);
+        testSubject.allowCaptureAt(1, 2);
+    }
+
+}

--- a/ChessProject-Java/src/test/java/com/solarwindsmsp/chess/PawnBlackMoveTest.java
+++ b/ChessProject-Java/src/test/java/com/solarwindsmsp/chess/PawnBlackMoveTest.java
@@ -1,0 +1,26 @@
+package com.solarwindsmsp.chess;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PawnBlackMoveTest {
+
+    private ChessBoard chessBoard;
+    private Pawn testSubject;
+
+    @Before
+    public void setUp() {
+        this.chessBoard = new ChessBoard();
+        this.testSubject = new Pawn(PieceColor.BLACK);
+    }
+
+    @Test
+    public void testPawn_Move_IllegalCoordinates_Back_InBlack_DoesNotMove() {
+        chessBoard.Add(testSubject, 4, 4, PieceColor.BLACK);
+        testSubject.Move(MovementType.MOVE, 4, 5);
+        assertEquals(4, testSubject.getXCoordinate());
+        assertEquals(4, testSubject.getYCoordinate());
+    }
+}

--- a/ChessProject-Java/src/test/java/com/solarwindsmsp/chess/PawnWhiteMoveTest.java
+++ b/ChessProject-Java/src/test/java/com/solarwindsmsp/chess/PawnWhiteMoveTest.java
@@ -1,0 +1,63 @@
+package com.solarwindsmsp.chess;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PawnWhiteMoveTest {
+    private ChessBoard chessBoard;
+    private Pawn testSubject;
+
+    @Before
+    public void setUp() {
+        this.chessBoard = new ChessBoard();
+        this.testSubject = new Pawn(PieceColor.WHITE);
+    }
+
+    @Test
+    public void testChessBoard_Add_Sets_XCoordinate() {
+        this.chessBoard.Add(testSubject, 4, 1, PieceColor.WHITE);
+        assertEquals(4, testSubject.getXCoordinate());
+    }
+
+    @Test
+    public void testChessBoard_Add_Sets_YCoordinate() {
+        this.chessBoard.Add(testSubject, 4, 1, PieceColor.WHITE);
+        assertEquals(1, testSubject.getYCoordinate());
+    }
+
+
+    @Test
+    public void testPawn_Move_IllegalCoordinates_Right_DoesNotMove() {
+        chessBoard.Add(testSubject, 4, 1, PieceColor.WHITE);
+        testSubject.Move(MovementType.MOVE, 5, 1);
+        assertEquals(4, testSubject.getXCoordinate());
+        assertEquals(1, testSubject.getYCoordinate());
+    }
+
+    @Test
+    public void testPawn_Move_IllegalCoordinates_Left_DoesNotMove() {
+        chessBoard.Add(testSubject, 4, 1, PieceColor.WHITE);
+        testSubject.Move(MovementType.MOVE, 5, 1);
+        assertEquals(4, testSubject.getXCoordinate());
+        assertEquals(1, testSubject.getYCoordinate());
+    }
+
+    @Test
+    public void testPawn_Move_IllegalCoordinates_Back_DoesNotMove() {
+        chessBoard.Add(testSubject, 4, 1, PieceColor.WHITE);
+        testSubject.Move(MovementType.MOVE, 4, 0);
+        assertEquals(4, testSubject.getXCoordinate());
+        assertEquals(1, testSubject.getYCoordinate());
+    }
+
+    @Test
+    public void testPawn_Move_LegalCoordinates_Forward_UpdatesCoordinates() {
+        chessBoard.Add(testSubject, 4, 1, PieceColor.WHITE);
+        testSubject.Move(MovementType.MOVE, 4, 2);
+        assertEquals(4, testSubject.getXCoordinate());
+        assertEquals(2, testSubject.getYCoordinate());
+    }
+
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**IMPORTANT:** This repository has been deprecated and archived. Please use the one hosted [here](https://github.com/solarwinds/ChessProject).
+
 # Solarwinds MSP Technical Exercise - ChessProject
 
 Welcome to the technical exercise used to assess candidates for Developer roles at Solarwinds MSP.


### PR DESCRIPTION
- Tried to abstract the concept of the "Piece" to facilitate the implementation of the other types of pieces in the future. Defined an interface IPiece that describes the actions that can be performed on a Piece and all future Piece types should implement this interface. The methods from the ChessBoard class being modified to accept the type.
- The Pawn class and future classes that will describe the behavior of the other Pieces also inherit the abstract Piece class that implements aspects common to these pieces. It defines and invokes 2 abstract allowMoveTo and allowCaptureTo methods that will allow specific implementations for each piece type
- Implemented the pawn move functionality as described depending on color and position.
- Added some additional tests to check the cases for moving the white pawns and some methods that did not seem to be covered by the existing tests.

I think that the structure of the application can be further improved, but not without modifying the existing tests. some short-term proposals:
 - The pieceColor parameter in the ChessBoard.Add method seems redundant and can be confusing. It is already defined when instantiating the Pawn (piece) object 
-  Maybe some change is required regarding how ChessBoard - Pawn (PIece) are linked. At the moment it seems to me that the information about coordinates is kept in both  ChessBoard and Pawn (Piece).
-  ChessBoard.IsLegalBoardPostion should also take into account the color of the piece